### PR TITLE
Use relative path for discovering definitions

### DIFF
--- a/dags/benk/common.py
+++ b/dags/benk/common.py
@@ -1,6 +1,4 @@
-import os
 from datetime import timedelta
-from pathlib import Path
 
 from airflow.models import Variable
 
@@ -17,5 +15,3 @@ BaseOperaterArgs = {
 TEAM_NAME = "BenK"
 NAMESPACE = Variable.get("pod-namespace", default_var="airflow")
 REGISTRY_URL = Variable.get("pod-container-registry-url", default_var=None)
-
-AIRFLOW_HOME = Path(os.environ.get("AIRFLOW_HOME", "/opt/airflow"))

--- a/dags/benk/definitions/__init__.py
+++ b/dags/benk/definitions/__init__.py
@@ -33,7 +33,7 @@ class Workflow(BaseModel):
 
     @property
     def handler(self) -> Handler:
-        """Returns handler belonging to `workflow`."""
+        """Return handler belonging to `workflow`."""
         class_name = self.workflow.title()
 
         try:
@@ -69,7 +69,7 @@ class _Definitions:
     _path = AIRFLOW_HOME / "dags" / "benk" / "definitions"
 
     def __iter__(self) -> Iterator[Model]:
-        """Yields a parsed Model from all json objects found in path."""
+        """Yield a parsed Model from all json objects found in path."""
         for obj in self._path.glob("*.json"):
             yield Model.parse_file(obj, encoding="utf-8")
 

--- a/dags/benk/definitions/__init__.py
+++ b/dags/benk/definitions/__init__.py
@@ -1,7 +1,7 @@
 import importlib
+from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Union
 
-from benk.common import AIRFLOW_HOME
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
@@ -66,11 +66,16 @@ class Model(BaseModel):
 
 class _Definitions:
 
-    _path = AIRFLOW_HOME / "dags" / "benk" / "definitions"
+    _path = Path(__file__).parent
 
     def __iter__(self) -> Iterator[Model]:
         """Yield a parsed Model from all json objects found in path."""
-        for obj in self._path.glob("*.json"):
+        objs = list(self._path.glob("*.json"))
+
+        if not objs:
+            raise FileNotFoundError(f"Definitions folder is empty: {self._path}")
+
+        for obj in objs:
             yield Model.parse_file(obj, encoding="utf-8")
 
 

--- a/dags/benk/environment.py
+++ b/dags/benk/environment.py
@@ -31,18 +31,20 @@ class OperatorEnvironment:
 
 
 class GenericEnvironment(OperatorEnvironment):
-    """Miscellaneous settings shared between containers"""
+    """Miscellaneous settings shared between containers."""
 
     GOB_SHARED_DIR = Variable.get("GOB-SHARED-DIR", "/app/shared")
 
 
 class GOBEnvironment(OperatorEnvironment):
-    """Settings to connect to connect to the GOB database.
+    """
+    Settings to connect to connect to the GOB database.
 
     Note: this provides env vars for the dict 'GOB_DB' in config.py in
     gobupload and not in gobconfig. Gobconfig uses GOB_DATABASE_* as env var
     names, instead of DATABASE_*.
     """
+
     DATABASE_USER = Variable.get("gob-database-user", "gob")
     DATABASE_NAME = Variable.get("gob-database-name", "gob")
     DATABASE_PASSWORD = Variable.get("gob-database-password")

--- a/dags/benk/image.py
+++ b/dags/benk/image.py
@@ -2,18 +2,29 @@ from benk.common import REGISTRY_URL
 
 
 class Image:
+    """Class to define Image logic."""
+
     def __init__(self, name: str, tag: str):
         self.name = name
         self.tag = tag
 
     @property
-    def pull_policy(self):
-        # Pull policy 'Never' prevents importing from a remote repository.
-        # This either uses a cached image or a locally built image.
+    def pull_policy(self) -> str:
+        """
+        Return policy for pulling current image.
+
+        Pull policy 'Never' prevents importing from a remote repository.
+        This either uses a cached image or a locally built image.
+        """
         return "Never" if REGISTRY_URL is None else "Always"
 
     @property
-    def url(self):
+    def url(self) -> str:
+        """
+        Return image url.
+
+        This either includes a registry or not when image is local.
+        """
         if REGISTRY_URL is None:
             return f"{self.name}:{self.tag}"
 

--- a/dags/benk/volume.py
+++ b/dags/benk/volume.py
@@ -6,7 +6,7 @@ from kubernetes.client import (
 
 
 class Volume:
-    """Volume definition to be passed to the DAG through its properties"""
+    """Volume definition to be passed to the DAG through its properties."""
 
     def __init__(self, name: str, mount_path: str, claim: str):
         self.name = name
@@ -14,12 +14,14 @@ class Volume:
         self.claim = claim
 
     @property
-    def v1mount(self):
+    def v1mount(self) -> V1VolumeMount:
+        """Return volume mount used in a KubernetesPodOperator."""
         return V1VolumeMount(
             name=self.name, mount_path=self.path, sub_path=None, read_only=False
         )
 
     @property
-    def v1volume(self):
+    def v1volume(self) -> V1Volume:
+        """Return volume using claim, used in a KubernetesPodOperator."""
         pvc = V1PersistentVolumeClaimVolumeSource(claim_name=self.claim)
         return V1Volume(name=self.name, persistent_volume_claim=pvc)

--- a/dags/benk/workflow/workflow.py
+++ b/dags/benk/workflow/workflow.py
@@ -76,18 +76,27 @@ ImportArgs = dict(
 
 
 class BaseDAG:
+    """
+    Base DAG abstraction.
 
-    Operator = KubernetesPodOperator
+    Implement `tasks` method to return a list of tasks to be executed sequentially.
+    """
+
+    Operator: KubernetesPodOperator = KubernetesPodOperator
 
     @classmethod
     @abstractmethod
-    def tasks(cls):  # pragma: no cover
+    def tasks(cls) -> list[Operator]:  # pragma: no cover
+        """Return list of tasks."""
         pass
 
 
 class Import(BaseDAG):
+    """Define import workflow."""
+
     @classmethod
     def import_(cls):
+        """Define an import task."""
         return cls.Operator(
             task_id="import",
             name="import",  # required
@@ -103,6 +112,7 @@ class Import(BaseDAG):
 
     @classmethod
     def update(cls):
+        """Define an update model task."""
         return cls.Operator(
             task_id="update",
             name="update",
@@ -116,6 +126,7 @@ class Import(BaseDAG):
 
     @classmethod
     def compare(cls):
+        """Define a compare task."""
         return cls.Operator(
             task_id="compare",
             name="compare",
@@ -129,6 +140,7 @@ class Import(BaseDAG):
 
     @classmethod
     def upload(cls):
+        """Define an upload events task."""
         return cls.Operator(
             task_id="upload",
             name="upload",
@@ -142,6 +154,7 @@ class Import(BaseDAG):
 
     @classmethod
     def apply(cls):
+        """Define an apply events task."""
         return cls.Operator(
             task_id="apply",
             name="apply",
@@ -155,6 +168,7 @@ class Import(BaseDAG):
 
     @classmethod
     def tasks(cls):
+        """Define a list of tasks to perform for an Import."""
         return [
             cls.import_(),
             cls.update(),
@@ -165,8 +179,11 @@ class Import(BaseDAG):
 
 
 class Relate(BaseDAG):
+    """Define a Relate workflow."""
+
     @classmethod
     def prepare(cls):
+        """Define a prepare relate task."""
         return cls.Operator(
             task_id="prepare",
             name="prepare",
@@ -182,6 +199,7 @@ class Relate(BaseDAG):
 
     @classmethod
     def process(cls):
+        """Define a relate process task."""
         return cls.Operator(
             task_id="process",
             name="process",
@@ -195,6 +213,7 @@ class Relate(BaseDAG):
 
     @classmethod
     def update(cls):
+        """Define a update events task."""
         return cls.Operator(
             task_id="update",
             name="update",
@@ -208,6 +227,7 @@ class Relate(BaseDAG):
 
     @classmethod
     def apply(cls):
+        """Define an apply events task."""
         return cls.Operator(
             task_id="apply",
             name="apply",
@@ -221,6 +241,7 @@ class Relate(BaseDAG):
 
     @classmethod
     def update_view(cls):
+        """Define a relate update view task."""
         return cls.Operator(
             task_id="update_view",
             name="update_view",
@@ -234,6 +255,7 @@ class Relate(BaseDAG):
 
     @classmethod
     def check(cls):
+        """Define a relate check task."""
         return cls.Operator(
             task_id="check",
             name="check",
@@ -247,6 +269,7 @@ class Relate(BaseDAG):
 
     @classmethod
     def tasks(cls):
+        """Define a list of tasks to perform for an Import."""
         return [
             cls.prepare(),
             cls.process(),

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -26,6 +27,14 @@ class TestDefinitions:
               ]
             }
         assert model_definition[0].json() == json.dumps(result)
+
+    def test_iter_empty_folder(self, monkeypatch):
+        with monkeypatch.context():
+            monkeypatch.setattr("benk.definitions._Definitions._path", Path("/"))
+
+            with pytest.raises(FileNotFoundError):
+                from benk.definitions import DEFINITIONS
+                list(DEFINITIONS)
 
     def test_workflow_handler(self, model_definition):
         model = model_definition[0]


### PR DESCRIPTION
- Azure has a different DAG folder, use relative path to __init__.py
- Raise on no DAG definitons found/defined to show during import runtime on Airflow

on top of https://github.com/Amsterdam/benk-airflow/pull/24