### PR TITLE
Add migrate task before imports

### DIFF
--- a/dags/benk/generate.py
+++ b/dags/benk/generate.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime
 
 from airflow import DAG
-from airflow.models.baseoperator import chain, cross_downstream
+from airflow.models.baseoperator import cross_downstream
 
 from benk.common import BaseOperaterArgs
 from benk.definitions import DEFINITIONS
@@ -34,7 +34,7 @@ for definition in DEFINITIONS:
             ]
 
         # Start with initialising / migrating before imports
-        chain(*initialise.get_leaf_nodes(), flatten_list([i.get_start_nodes() for i in imports]))
+        cross_downstream(initialise.get_leaf_nodes(), flatten_list([i.get_start_nodes() for i in imports]))
 
         # Link imports to relates
         cross_downstream(
@@ -45,4 +45,4 @@ for definition in DEFINITIONS:
             prepare = Prepare(definition.catalog)
 
             # Add Prepare
-            chain(prepare.get_leaf_nodes(), *initialise.get_start_nodes())
+            cross_downstream(prepare.get_leaf_nodes(), initialise.get_start_nodes())

--- a/dags/benk/workflow/__init__.py
+++ b/dags/benk/workflow/__init__.py
@@ -1,5 +1,6 @@
 from .import_ import Import
+from .initialise import Initialise
 from .prepare import Prepare
 from .relate import Relate
 
-__all__ = ["Import", "Relate", "Prepare"]
+__all__ = ["Import", "Relate", "Prepare", "Initialise"]

--- a/dags/benk/workflow/initialise.py
+++ b/dags/benk/workflow/initialise.py
@@ -1,0 +1,33 @@
+from airflow.models.baseoperator import BaseOperator, chain
+
+from benk.workflow.workflow import BaseDAG, UploadArgs
+
+
+class Initialise(BaseDAG):
+    """DAG containing initial tasks to perform before starting jobs."""
+
+    def get_leaf_nodes(self) -> list[BaseOperator]:
+        """Return leaf node(s). In this case should be 1 node."""
+        return [self._tasks[-1]]
+
+    def get_start_nodes(self) -> list[BaseOperator]:
+        """Return start node(s). In this case should be 1 node."""
+        return [self._tasks[0]]
+
+    @property
+    def id(self) -> str:
+        """Name to identify this DAG."""
+        return "initialise"
+
+    def __init__(self):
+        self._tasks = [self._migrate()]
+        chain(*self._tasks)
+
+    def _migrate(self):
+        name = "migrate"
+        return self.Operator(
+            name=name,
+            task_id=self.get_taskid(name),
+            arguments=["migrate"],
+            **UploadArgs,
+        )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -49,7 +49,6 @@ class TestGenerate:
             patch("benk.workflow.Prepare", MockPrepareDag),
             patch("benk.workflow.Initialise", MockInitialiseDag),
             patch("airflow.models.baseoperator.cross_downstream") as mock_cross_downstream,
-            patch("airflow.models.baseoperator.chain") as mock_chain
         ):
 
             # run generate DAG
@@ -66,12 +65,9 @@ class TestGenerate:
                 start_date=datetime.utcnow(),
             )
 
-            mock_chain.assert_has_calls([
-                call('initialise-', ['import-nap_peilmerken_Grondslag']),
-                call(['prepare-nap'], 'initialise-')
-            ])
-
             mock_cross_downstream.assert_has_calls([
+                call(["initialise-"], ["import-nap_peilmerken_Grondslag"]),
                 call(["import-nap_peilmerken_Grondslag"],
                      ["relate-nap_peilmerken_relation_attribute_1", "relate-nap_peilmerken_relation_attribute_2"]),
+                call(["prepare-nap"], ["initialise-"])
             ])

--- a/tests/workflow/test_initialise.py
+++ b/tests/workflow/test_initialise.py
@@ -1,0 +1,27 @@
+from unittest import mock, TestCase
+
+from tests.mocks import mock_get_variable
+
+
+@mock.patch("airflow.models.Variable", mock_get_variable)
+class TestWorkflow(TestCase):
+
+    @mock.patch("benk.workflow.import_.chain")
+    def setUp(self, mock_chain):
+        from benk.workflow import Initialise
+        self.mock_chain = mock_chain
+        self.init = Initialise()
+
+    def test_initialise(self):
+        init_ = self.init
+        assert init_.id == "initialise"
+        assert len(init_._tasks) == 1
+
+        names = ["migrate"]
+        assert all(task.name == name for task, name in zip(init_._tasks, names))
+
+        leafs = ["migrate"]
+        starts = ["migrate"]
+
+        assert [n.name for n in init_.get_leaf_nodes()] == leafs
+        assert [n.name for n in init_.get_start_nodes()] == starts


### PR DESCRIPTION
Migrate task, as part of initialise DAG, is inserted once before all  import tasks. 
The last node(s) of prepare is linked to this DAG if available.