### PR TITLE
Add ALL_DONE trigger rule to relate start node

### DIFF
--- a/dags/benk/workflow/relate.py
+++ b/dags/benk/workflow/relate.py
@@ -9,8 +9,8 @@ class Relate(BaseDAG):
 
     XCOM_MAPPER = {
         "process": "prepare",
-        "update": "process",
-        "apply": "update",
+        "upload": "process",
+        "apply": "upload",
         "update_view": "apply",
         "check": "update_view",
     }
@@ -53,8 +53,8 @@ class Relate(BaseDAG):
             **UploadArgs,
         )
 
-    def _update(self):
-        name = "update"
+    def _upload(self):
+        name = "upload"
         return self.Operator(
             name=name,
             task_id=self.get_taskid(name),
@@ -97,7 +97,7 @@ class Relate(BaseDAG):
         self._tasks = [
             self._prepare(),
             self._process(),
-            self._update(),
+            self._upload(),
             self._apply(),
             self._update_view(),
             self._check(),

--- a/dags/benk/workflow/relate.py
+++ b/dags/benk/workflow/relate.py
@@ -1,4 +1,5 @@
 from airflow.models.baseoperator import BaseOperator, chain
+from airflow.utils.trigger_rule import TriggerRule
 
 from benk.workflow.workflow import BaseDAG, UploadArgs, XCom
 
@@ -38,6 +39,7 @@ class Relate(BaseDAG):
                 f"--collection={self.collection}",
                 f"--attribute={self.attribute}",
             ],
+            trigger_rule=TriggerRule.ALL_DONE,  # trigger task when dependency is done, fail or success
             **UploadArgs,
         )
 

--- a/tests/workflow/test_relate.py
+++ b/tests/workflow/test_relate.py
@@ -1,5 +1,6 @@
 from unittest import mock, TestCase
 
+from airflow.utils.trigger_rule import TriggerRule
 from tests.mocks import mock_get_variable
 
 
@@ -23,3 +24,6 @@ class TestWorkflow(TestCase):
             assert [n.name for n in relate.get_start_nodes()] == starts
 
             mock_chain.assert_called_with(*relate._tasks)
+
+            assert relate.get_start_nodes()[0].trigger_rule == TriggerRule.ALL_DONE
+

--- a/tests/workflow/test_relate.py
+++ b/tests/workflow/test_relate.py
@@ -14,7 +14,7 @@ class TestWorkflow(TestCase):
             assert len(relate._tasks) == 6
 
             # Notice: dash instead of underscore for update_view
-            names = ["prepare", "process", "update", "apply", "update-view", "check"]
+            names = ["prepare", "process", "upload", "apply", "update-view", "check"]
             assert all(task.name == name for task, name in zip(relate._tasks, names))
 
             leafs = ["check"]
@@ -26,4 +26,3 @@ class TestWorkflow(TestCase):
             mock_chain.assert_called_with(*relate._tasks)
 
             assert relate.get_start_nodes()[0].trigger_rule == TriggerRule.ALL_DONE
-


### PR DESCRIPTION
- Start relate tasks when previous are done, success or failure.
- Rename update task to upload (= uploading/storing events task)